### PR TITLE
Fix aimlapi base url

### DIFF
--- a/examples/aimlapi/README.md
+++ b/examples/aimlapi/README.md
@@ -8,11 +8,6 @@ Set your API key:
 export AIML_API_KEY=your_api_key_here
 ```
 
-If you need to target a self-hosted endpoint, also set the base URL:
-```bash
-export AIML_API_BASE_URL=https://your-hosted-api/v1
-```
-
 Run the example:
 
 ```bash

--- a/site/docs/providers/aimlapi.md
+++ b/site/docs/providers/aimlapi.md
@@ -41,5 +41,4 @@ curl https://api.aimlapi.com/models -H "Authorization: Bearer $AIML_API_KEY"
 | Variable            | Description                                   |
 | ------------------- | --------------------------------------------- |
 | `AIML_API_KEY`      | API key for authentication                    |
-| `AIML_API_BASE_URL` | Override the API base URL (defaults to `https://api.aimlapi.com/v1`) |
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -66,9 +66,6 @@
                             "AI21_API_KEY": {
                               "type": "string"
                             },
-                            "AIML_API_BASE_URL": {
-                              "type": "string"
-                            },
                             "AIML_API_KEY": {
                               "type": "string"
                             },

--- a/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
+++ b/src/app/src/pages/eval-creator/components/ConfigureEnvButton.tsx
@@ -151,13 +151,6 @@ const ConfigureEnvButton: React.FC = () => {
                 value={env.AIML_API_KEY}
                 onChange={(e) => setEnv({ ...env, AIML_API_KEY: e.target.value })}
               />
-              <TextField
-                label="AI/ML API base URL"
-                fullWidth
-                margin="normal"
-                value={env.AIML_API_BASE_URL}
-                onChange={(e) => setEnv({ ...env, AIML_API_BASE_URL: e.target.value })}
-              />
             </AccordionDetails>
           </Accordion>
         </DialogContent>

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -155,7 +155,6 @@ export type EnvVars = {
   AI21_API_KEY?: string;
 
   // AIML API
-  AIML_API_BASE_URL?: string;
   AIML_API_KEY?: string;
 
   // Anthropic

--- a/src/providers/aimlapi.ts
+++ b/src/providers/aimlapi.ts
@@ -66,11 +66,7 @@ export function createAimlApiProvider(
     ...options,
     config: {
       ...(options.config || {}),
-      apiBaseUrl:
-        options.config?.env?.AIML_API_BASE_URL ||
-        options.env?.AIML_API_BASE_URL ||
-        getEnvString('AIML_API_BASE_URL') ||
-        'https://api.aimlapi.com/v1',
+      apiBaseUrl: 'https://api.aimlapi.com/v1',
       apiKeyEnvar: 'AIML_API_KEY',
     } as OpenAiCompletionOptions,
   };

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 export const ProviderEnvOverridesSchema = z.object({
   AI21_API_BASE_URL: z.string().optional(),
   AI21_API_KEY: z.string().optional(),
-  AIML_API_BASE_URL: z.string().optional(),
   AIML_API_KEY: z.string().optional(),
   ANTHROPIC_API_KEY: z.string().optional(),
   ANTHROPIC_BASE_URL: z.string().optional(),


### PR DESCRIPTION
## Summary
- hardcode the AIML base URL in `createAimlApiProvider`
- remove `AIML_API_BASE_URL` from env schema, env var list and docs
- drop the optional base URL input in the web UI and example docs
- prune leftover mention about the base URL in the provider docs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*


------
https://chatgpt.com/codex/tasks/task_e_6863c8ccaf1c8329b4082daeb66bc07e